### PR TITLE
Refactor query API by keyword

### DIFF
--- a/app/nginx.conf
+++ b/app/nginx.conf
@@ -1,5 +1,5 @@
 server {
-  listen 80 ssl;
+  listen 80;
   location / {
     rewrite ^/ui(/.*)$ $1 break;
     root /usr/share/nginx/html;

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,13 +8,11 @@ With an introduction to the core concepts in the previous sections, lets move on
 
 1. Install Minikube
 
-{% embed url="https://github.com/kubernetes/minikube" %}
+https://github.com/kubernetes/minikube
 
 2. Once minikube is up and running, Note that cluster `minikube`  and namespace `default` exists after the above steps. The yaml files used in the Installation use this cluster and namespace.
 
-{% hint style="info" %}
-If using another cluster and namespace, the K-Atlas Installation yaml files will need to be modified to use the correct cluster and namespace.
-{% endhint %}
+*If using another cluster and namespace, the K-Atlas Installation yaml files will need to be modified to use the correct cluster and namespace.*
 
 ```text
 $ kubectl config get-clusters
@@ -51,7 +49,7 @@ NAME                                 READY   STATUS    RESTARTS   AGE
 dgraph-0                             3/3     Running   0          1d
 ```
 
-Setup Dgraph with the Schema and Metadata \[TODO- This step is temporary, after more code changes, it will be done by the code\]
+Setup Dgraph with the Schema and Metadata-
 
 ```text
 cd deploy/
@@ -76,13 +74,13 @@ $ kubectl create -f deploy/katlas-collector.yaml
 
 Install K-Atlas Browser
 
-{% hint style="info" %}
+
 Modify the below env variable in deploy/katlas-browser.yaml and then run the kubectl command.
 
 KATLAS\_API\_URL
 
 value: http://&lt;minikube-ip&gt;:30415
-{% endhint %}
+
 
 ```text
 $ kubectl create -f deploy/katlas-browser.yaml
@@ -93,10 +91,10 @@ Check all pods are up
 ```text
 $ kubectl get pods
 NAME                                 READY   STATUS    RESTARTS   AGE
-dgraph-0                             3/3     Running   9          1d
-katlas-service-748668b795-wt6gk      1/1     Running   3          1d
-katlas-controller-8586d84564-njrvr   1/1     Running   3          1d
-katlas-browser-5875c79c64-2zhwk      1/1     Running   3          1d
+dgraph-0                             3/3     Running   0          1d
+katlas-service-748668b795-wt6gk      1/1     Running   0          1d
+katlas-controller-8586d84564-njrvr   1/1     Running   0          1d
+katlas-browser-5875c79c64-2zhwk      1/1     Running   0          1d
 ```
 
 Check all Services are running
@@ -114,9 +112,8 @@ If using minikube, point your browser to the following URL to start using K-Atla
 http://<minikube-ip>:30417
 ```
 
-{% hint style="info" %}
-Ensure you use the Chrome browser. For issues with Installation, please refer to the FAQ Section.
-{% endhint %}
+
+**Ensure you use the Chrome browser. For issues with Installation, please refer to the FAQ Section.**
 
 
 

--- a/service/apis/entity_service.go
+++ b/service/apis/entity_service.go
@@ -41,7 +41,7 @@ type EntityService struct {
 }
 
 // NewEntityService creates a new EntityService with the given dgraph client.
-func NewEntityService(dc *db.DGClient, msvc *MetaService) *EntityService {
+func NewEntityService(dc db.IDGClient, msvc *MetaService) *EntityService {
 	return &EntityService{dc, msvc}
 }
 
@@ -58,7 +58,8 @@ func (s EntityService) DeleteEntity(uuid string) error {
 // DeleteEntityByResourceID remove object by given resourceid
 func (s EntityService) DeleteEntityByResourceID(meta string, rid string) error {
 	qm := map[string][]string{util.ResourceID: {rid}, util.ObjType: {meta}}
-	node, err := s.dbclient.GetQueryResult(qm)
+	queryService := NewQueryService(s.dbclient)
+	node, err := queryService.GetQueryResult(qm)
 	if err != nil {
 		log.Error(err)
 		return err
@@ -166,7 +167,8 @@ func (s EntityService) CreateEntity(meta string, data map[string]interface{}) (m
 		defer mutex.Unlock(data[util.ResourceID])
 		// check if entity already exist
 		qm := map[string][]string{util.ResourceID: {data[util.ResourceID].(string)}, util.ObjType: {meta}}
-		node, err := s.dbclient.GetQueryResult(qm)
+		queryService := NewQueryService(s.dbclient)
+		node, err := queryService.GetQueryResult(qm)
 		if err != nil {
 			log.Error(err)
 			return nil, err
@@ -286,7 +288,8 @@ func buildDataMap(isJSON bool, relData interface{}, relType string, cluster stri
 func (s EntityService) getUIDFromRelData(data map[string]interface{}, objType string) (*string, error) {
 	// query by ResourceID to get uid
 	qm := map[string][]string{util.ResourceID: {data[util.ResourceID].(string)}, util.ObjType: {objType}}
-	node, err := s.dbclient.GetQueryResult(qm)
+	queryService := NewQueryService(s.dbclient)
+	node, err := queryService.GetQueryResult(qm)
 	if err != nil {
 		log.Error(err)
 		return nil, err

--- a/service/apis/meta_service.go
+++ b/service/apis/meta_service.go
@@ -62,7 +62,8 @@ func (s MetaService) GetMetadata(name string) (Metadata, error) {
 	qm := map[string][]string{util.Name: {name}, util.ObjType: {util.Metadata}}
 	// Get metadata by name
 	n := Metadata{}
-	metas, err := s.dbclient.GetQueryResult(qm)
+	queryService := NewQueryService(s.dbclient)
+	metas, err := queryService.GetQueryResult(qm)
 	if err != nil {
 		return n, err
 	}
@@ -80,7 +81,7 @@ func (s MetaService) GetMetadata(name string) (Metadata, error) {
 }
 
 // NewMetaService creates a new MetaService with the given dgraph client.
-func NewMetaService(dc *db.DGClient) *MetaService {
+func NewMetaService(dc db.IDGClient) *MetaService {
 	return &MetaService{dc}
 }
 
@@ -88,7 +89,8 @@ func NewMetaService(dc *db.DGClient) *MetaService {
 func (s MetaService) GetMetadataFields(name string) ([]MetadataField, error) {
 	qm := map[string][]string{util.Name: {name}, util.ObjType: {util.Metadata}}
 	// Get metadata by name
-	metas, err := s.dbclient.GetQueryResult(qm)
+	queryService := NewQueryService(s.dbclient)
+	metas, err := queryService.GetQueryResult(qm)
 	if err != nil {
 		return nil, err
 	}

--- a/service/apis/query_service.go
+++ b/service/apis/query_service.go
@@ -66,13 +66,13 @@ func (s QueryService) getQueryResultByKeyword(keyword string) (string, error) {
 	qr = "{"
 
 	for _, schemanode := range smds {
-		fmt.Printf("Predicate: %v Type: %v tokenizer: %v\n", schemanode.Predicate, schemanode.Type, schemanode.Tokenizer)
+		log.Debugf("Predicate: %v Type: %v tokenizer: %v\n", schemanode.Predicate, schemanode.Type, schemanode.Tokenizer)
 
 		if schemanode.Type == "string" && schemanode.Index == true && len(schemanode.Tokenizer) > 0 {
 			for _, tokenizer := range schemanode.Tokenizer {
 				tk := tokenizer
 				if tk == "trigram" {
-					fmt.Printf("Found ***** Predicate: %v Type: %v tokenizer: %v\n", schemanode.Predicate, schemanode.Type, schemanode.Tokenizer)
+					log.Debugf("Found ***** Predicate: %v Type: %v tokenizer: %v\n", schemanode.Predicate, schemanode.Type, schemanode.Tokenizer)
 					filter := "obj" + strconv.Itoa(cnt) + "(func:regexp(" + schemanode.Predicate + ",/" + keyword + "/i)) {"
 					qr = qr + filter + `
 						uid

--- a/service/apis/query_service.go
+++ b/service/apis/query_service.go
@@ -1,8 +1,16 @@
 package apis
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
 	"github.com/intuit/katlas/service/db"
 )
+
+//QueryParamKeyword ...param for keyword query
+const QueryParamKeyword = "keyword"
 
 //IQueryService ...define interfaces to query data
 type IQueryService interface {
@@ -15,11 +23,105 @@ type QueryService struct {
 }
 
 //NewQueryService ...Create NewQueryService
-func NewQueryService(dc *db.DGClient) *QueryService {
+func NewQueryService(dc db.IDGClient) *QueryService {
 	return &QueryService{dc}
 }
 
 //GetQueryResult ...Api to get Query Results
 func (s QueryService) GetQueryResult(queryMap map[string][]string) (map[string]interface{}, error) {
-	return s.dbclient.GetQueryResult(queryMap)
+	var q string
+	var err error
+
+	val, ok := queryMap[QueryParamKeyword]
+	if ok {
+		if val[0] == "" {
+			err := fmt.Errorf("Value not specified for Query Param [%s]", QueryParamKeyword)
+			return nil, err
+		}
+		q, err = s.getQueryResultByKeyword(val[0])
+		if err != nil {
+			log.Debug(err)
+			return nil, err
+		}
+	} else {
+		if len(queryMap) == 0 {
+			err := fmt.Errorf("Query Params not specified")
+			return nil, err
+		}
+		q = getQueryResultByKeyValue(queryMap)
+	}
+
+	return s.dbclient.GetQueryResult(q)
+}
+
+// Keyword query http://<dgraph ip:port>/v1/query?keyword=pod
+func (s QueryService) getQueryResultByKeyword(keyword string) (string, error) {
+	smds, err := s.dbclient.GetSchema()
+	if err != nil {
+		log.Debug(err)
+		return "", err
+	}
+	cnt := 0
+	var qr string
+	qr = "{"
+
+	for _, schemanode := range smds {
+		fmt.Printf("Predicate: %v Type: %v tokenizer: %v\n", schemanode.Predicate, schemanode.Type, schemanode.Tokenizer)
+
+		if schemanode.Type == "string" && schemanode.Index == true && len(schemanode.Tokenizer) > 0 {
+			for _, tokenizer := range schemanode.Tokenizer {
+				tk := tokenizer
+				if tk == "trigram" {
+					fmt.Printf("Found ***** Predicate: %v Type: %v tokenizer: %v\n", schemanode.Predicate, schemanode.Type, schemanode.Tokenizer)
+					filter := "obj" + strconv.Itoa(cnt) + "(func:regexp(" + schemanode.Predicate + ",/" + keyword + "/i)) {"
+					qr = qr + filter + `
+						uid
+	            		expand(_all_) {
+							uid
+							expand(_all_)
+						}
+					}
+					`
+				}
+
+			}
+		}
+		cnt++
+	}
+	qr = qr + "}"
+	log.Debugf("Query string is =%v\n", qr)
+	return qr, nil
+}
+
+// Key-Value query http://<dgraph ip:port>/v1/query?name=pod01&objtype=Pod
+func getQueryResultByKeyValue(queryMap map[string][]string) string {
+
+	//Only indexed fields can be filtered on
+	//Time must be in correct format "2018-10-18 14:36:32 -0700 PDT"
+	qps := []string{}
+	var funcStr, filterStr string
+
+	for k, v := range queryMap {
+		qp := "eq(" + k + ",\"" + v[0] + "\")"
+		qps = append(qps, qp)
+	}
+
+	funcStr = "(func:" + qps[0] + ") "
+	filters := qps[1:]
+	if len(filters) > 0 {
+		filterStr = "@filter(" + strings.Join(filters, " AND ") + ")"
+	}
+
+	q := `
+	{
+		objects` + funcStr + filterStr + ` {
+			uid
+			expand(_all_) {
+				uid
+				expand(_all_)
+			}
+		}
+	}
+	`
+	return q
 }

--- a/service/db/dgclient_test.go
+++ b/service/db/dgclient_test.go
@@ -1,9 +1,10 @@
 package db
 
 import (
+	"testing"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestDGClient(t *testing.T) {
@@ -84,6 +85,17 @@ func TestCreateIndex(t *testing.T) {
 	err := client.CreateSchema(s)
 	assert.Nil(t, err)
 	client.DropSchema("testindex")
+}
+
+func TestGetSchema(t *testing.T) {
+	client := NewDGClient("127.0.0.1:9080")
+	defer client.Close()
+	smds, err := client.GetSchema()
+	if err != nil {
+		log.Fatalf("failed to get schema %v", err)
+	}
+	log.Infof("From test schema returned: [%v]\n", smds)
+	assert.Nil(t, err)
 }
 
 func cleanUP(client *DGClient, uids map[string]string) {


### PR DESCRIPTION
Implement checking Dgraph schema predicate with index and type dynamically from database instead of hard coding:
- Add method GetSchema
- Moved most implementation code other than exact db process from dgclient to query_service
- Add test for GetSchema
- Implement checking db schema predicate on index and type trigram to apply filter for keyword searching
- Also make some small changes to meta_service and entity_service due to the query service code changes