### PR TITLE
extend base Router with basename

### DIFF
--- a/app/src/history.js
+++ b/app/src/history.js
@@ -1,5 +1,5 @@
 import { createBrowserHistory } from 'history'
 
 export default createBrowserHistory({
-  /* pass a configuration object here if needed */
+  basename: process.env.PUBLIC_URL
 })

--- a/app/src/history.js
+++ b/app/src/history.js
@@ -1,5 +1,10 @@
-import { createBrowserHistory } from 'history'
+import { createBrowserHistory } from 'history';
 
 export default createBrowserHistory({
+  //this value is not needed or used during local dev or testing scenarios
+  //instead, it's required in deployed scenarios where the application is
+  //deployed on a subdirectory of a host (ex: 'example.com/ui'). the value is
+  //provided by "homepage" attribute in package.json at webpack build time
+  //further info here: https://www.npmjs.com/package/history#using-a-base-url
   basename: process.env.PUBLIC_URL
 })

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -35,7 +35,7 @@ const theme = createMuiTheme({
 render(
   <MuiThemeProvider theme={theme}>
     <Provider store={store}>
-      <Router history={history} basename={process.env.PUBLIC_URL}>
+      <Router history={history}>
         <App/>
       </Router>
     </Provider>


### PR DESCRIPTION
extend base Router to support custom basename along with custom history provided

this allows the F/E app to understand that it's being hosted at someplace other than `/` on the host

in a scenario where the app is deployed to `<hostname>/ui/`, the basename provided to <BrowserRouter> allows this to be modified at build time (value comes from package.json)

when we recently changed from using a <BrowserRouter> to <Router> so as to pass it a custom history object (so that it could be modified in action files), we lost the basename capability and didn't immediately notice (since it has no effect in localhost dev server or tests)