### PR TITLE
Revert back to remove empty fields from data map while create entity

### DIFF
--- a/service/apis/entity_service.go
+++ b/service/apis/entity_service.go
@@ -98,7 +98,8 @@ func (s EntityService) CreateEntity(meta string, data map[string]interface{}) (m
 			if !ok || fieldValue == nil || ((reflect.ValueOf(fieldValue).Kind() == reflect.Interface ||
 				reflect.ValueOf(fieldValue).Kind() == reflect.Ptr ||
 				reflect.ValueOf(fieldValue).Kind() == reflect.Slice) &&
-				reflect.ValueOf(fieldValue).IsNil()) && field.FieldType == util.Relationship {
+				reflect.ValueOf(fieldValue).IsNil()) {
+				delete(data, field.FieldName)
 				continue
 			}
 			if strings.EqualFold(field.Cardinality, util.Many) || field.FieldType == util.Relationship {


### PR DESCRIPTION
the map could have <nil> value which will cause interface{} covert failure