### PR TITLE
fix one QSL projection issue

### DIFF
--- a/app/src/utils/validate.js
+++ b/app/src/utils/validate.js
@@ -11,7 +11,7 @@ export function validateIPaddress(ipaddress) {
 // get all the objects from a query string
 export function getQSLObjTypes(query) {
   const objTypes = [];
-  const querySegments = query.split('.');
+  const querySegments = query.split('}.');
   querySegments.forEach(segment => {
     const matches = QSLRegEx.exec(segment);
     if (matches) {
@@ -24,7 +24,7 @@ export function getQSLObjTypes(query) {
 // get all the object and the projection requested
 export function getQSLObjTypesAndProjection(query) {
   const queryProjection = {};
-  const querySegments = query.split('.');
+  const querySegments = query.split('}.');
   querySegments.forEach(segment => {
     const matches = QSLRegEx.exec(segment);
     if (matches) {

--- a/app/src/utils/validate.test.js
+++ b/app/src/utils/validate.test.js
@@ -26,11 +26,12 @@ describe('validation util', () => {
 
   it('should get all the obj types and projection', () => {
     const query =
-      'deployment{@name,@availablereplicas}.replicaset{*}.pod{*}.node[@name="ip-10-83-122-52.us-west-2.compute.internal"]{*}';
+      'deployment{@name,@availablereplicas}.replicaset{*}.pod{*}.node[@name="ip-10-83-122-52.us-west-2.compute.internal"]{@name}';
     const queryProjection = getQSLObjTypesAndProjection(query);
     expect(queryProjection.replicaset).toBe('*');
     expect(queryProjection.deployment).toHaveLength(2);
     expect(queryProjection.deployment).toContain('name');
     expect(queryProjection.deployment).toContain('availablereplicas');
+    expect(queryProjection.node).toContain('name');
   });
 });

--- a/service/Gopkg.lock
+++ b/service/Gopkg.lock
@@ -122,20 +122,9 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:ac83cf90d08b63ad5f7e020ef480d319ae890c208f8524622a2f3136e2686b02"
-  name = "github.com/stretchr/objx"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "477a77ecc69700c7cdeb1fa9e129548e1c1c393c"
-  version = "v0.1.1"
-
-[[projects]]
-  digest = "1:15a4a7e5afac3cea801fa24831fce3bf3b5bd3620cbf8355a07b7dbf06877883"
+  digest = "1:18752d0b95816a1b777505a97f71c7467a8445b8ffb55631a7bf779f6ba4fa83"
   name = "github.com/stretchr/testify"
-  packages = [
-    "assert",
-    "mock",
-  ]
+  packages = ["assert"]
   pruneopts = "UT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
@@ -317,7 +306,6 @@
     "github.com/hashicorp/golang-lru",
     "github.com/mitchellh/mapstructure",
     "github.com/stretchr/testify/assert",
-    "github.com/stretchr/testify/mock",
     "google.golang.org/grpc",
     "k8s.io/api/apps/v1",
     "k8s.io/api/apps/v1beta2",


### PR DESCRIPTION
If the query has '.' as value, the projection would not work. e.g. `namespace{*}.cluster[@name="paas-preprod-east2.cluster.k8s.local"]{@name}`